### PR TITLE
Fix potencial out of bounds exception

### DIFF
--- a/MCChildrenNavigationController/lib/MCChildrenNavigationController.m
+++ b/MCChildrenNavigationController/lib/MCChildrenNavigationController.m
@@ -203,6 +203,10 @@
 - (BOOL)childrenViewController:(MCChildrenViewController *)childrenViewController
        canNavigateToChildIndex:(NSInteger)childIndex
 {
+    if ([childrenViewController.node.children count] <= childIndex) {
+        return NO;
+    }
+    
     id<MCChildrenCollection> child = childrenViewController.node.children[childIndex];
     NSInteger childLevel = childrenViewController.level + 1;
     


### PR DESCRIPTION
Check if the child index is available before looking for it, avoiding a potencial out of bounds exception
